### PR TITLE
Readme Install Instructions Correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ nbmolviz.visualize(benzene)
 Requires npm.
 
     $ git clone https://github.com/autodesk/notebook-molecular-visualization.git
-    $ cd notebook-molecular-visualization/nbmolviz
+    $ cd notebook-molecular-visualization
     $ python setup.py jsdeps
     $ pip install -e .
     $ jupyter nbextension install --py --symlink --user nbmolviz


### PR DESCRIPTION
Quick fix: The `nbmolviz` path shouldn't be there in the dev install instructions, right?  `setup.py` is in the root folder, so the following command needs to happen in the root folder.
