### PR TITLE
MANIFEST.in improvement

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,4 @@ include requirements.txt
 include LICENSE
 include README.md
 global-exclude *.py[cod] __pycache__ *~ *.bak
+exclude js/**/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,4 +5,4 @@ include requirements.txt
 include LICENSE
 include README.md
 global-exclude *.py[cod] __pycache__ *~ *.bak
-exclude js/**/*
+recursive-exclude js *


### PR DESCRIPTION
Prevent tons of output when running `check-manifest` due to the node_modules directory.