### PR TITLE
Selection Type Bug

### DIFF
--- a/js/src/nbmolviz_3d_model.js
+++ b/js/src/nbmolviz_3d_model.js
@@ -29,7 +29,7 @@ const Nbmolviz3dModel = widgets.DOMWidgetModel.extend({
     },
     styles: {},
     selected_atom_indices: [],
-    selection_type: 'atom',
+    selection_type: 'Atom',
     shapes: [],
     width: '500px',
   },


### PR DESCRIPTION
This repo was providing an invalid selectionType to molecule-3d-for-react.  This PR uses a valid one.