### PR TITLE
Move MDT JSON converter into NBMolViz

### DIFF
--- a/nbmolviz/drivers3d.py
+++ b/nbmolviz/drivers3d.py
@@ -15,8 +15,9 @@ import numpy as np
 from StringIO import StringIO
 from traitlets import Bool, Dict, Float, List, Set, Unicode
 
-from nbmolviz.utils import JSObject, translate_color
-from nbmolviz.widget3d import MolViz3DBaseWidget
+from .utils import JSObject, translate_color
+from .widget3d import MolViz3DBaseWidget
+from .mdt2json import convert as convert_to_json
 
 
 class MolViz_3DMol(MolViz3DBaseWidget):
@@ -64,7 +65,7 @@ class MolViz_3DMol(MolViz3DBaseWidget):
     # Standard view actions
     def add_molecule(self, mol):
         self.mol = mol
-        self.model_data = self.mol.to_json()
+        self.model_data = convert_to_json(self.mol)
 
     def set_background_color(self, color, opacity=1.0):
         color = translate_color(color)

--- a/nbmolviz/mdt2json.py
+++ b/nbmolviz/mdt2json.py
@@ -1,0 +1,44 @@
+# Copyright 2016 Autodesk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def convert(mol):
+    from moldesign import units as u
+
+    js = dict(name=mol.name)
+
+    js['atoms'] = [{'serial': i,
+                    'name': atom.name,
+                    'elem': atom.elem,
+                    'mass_magnitude': atom.mass.value_in(u.amu),
+                    'residue_index': atom.residue.index,
+                    'residue_name': atom.residue.name,
+                    'chain': atom.chain.name,
+                    'positions': list(atom.position.value_in(u.angstrom))}
+                   for i, atom in enumerate(mol.atoms)]
+
+    js['bonds'] = [{'atom1_index': bond.a1.index,
+                    'atom2_index': bond.a2.index,
+                    'bond_order': bond.order}
+                   for i, bond in enumerate(mol.bonds)]
+
+    js['residues'] = [{'name': residue.name,
+                       'sequence_number': residue.pdbindex,
+                       'chain_index': residue.chain.index}
+                      for i, residue in enumerate(mol.residues)]
+
+    js['chains'] = [{'name': chain.name,
+                     'description': ''}
+                    for i, chain in enumerate(mol.chains)]
+    return js


### PR DESCRIPTION
This gives NBMolViz its own MDT-to-JSON converter so that messing around with JSON serialization in MDT won't screw up the visualization

The companion is PR to remove the experimental JSON stuff from MDT is at Autodesk/molecular-design-toolkit#117

@justinmc - this is ready to review