### PR TITLE
adding user=True to installing_nbext_py

### DIFF
--- a/nbmolviz/__init__.py
+++ b/nbmolviz/__init__.py
@@ -115,7 +115,8 @@ def _enable_nbextension():
         import notebook
         if not notebook.nbextensions.check_nbextension('nbmolviz-js'):
             print 'Installing Jupyter nbmolviz-js extension...',
-            notebook.nbextensions.install_nbextension_python('nbmolviz')
+            notebook.nbextensions.install_nbextension_python('nbmolviz',
+                    user=True)
             print 'done'
         notebook.nbextensions.enable_nbextension_python('widgetsnbextension')
         notebook.nbextensions.enable_nbextension_python('nbmolviz')


### PR DESCRIPTION
I was recently trying to play around with the molecular design toolkit and was having problems related to the nbmolviz extension. I came to a similar conclusion as Issue #63 in autodesk/molecular-design-toolkit, where upon import of moldesign, an attempt to install the extension to /usr/... (somewhere in root) is denied and doesn't allow viewing of molecules. 

In nbmolviz/__init__.py (118), when the enabling of the nbmolviz-js extension is invoked, it uses the notebook.nbextensions.install_nb_extension_python function which optionally takes in a 'user' argument which tells the app to install somewhere user has permissions. I added user=True to the arguments of this function.

I cleared out all previous install attempts of nbmolviz, and spun up a new jupyter notebook. Upon import moldesign, I received no warnings of attempted install to root, and was able to visualize molecules. 

I ran what py.tests I could in both this repo and mdt, with only the same errors that I previously had appearing. This seems a bit too good to be true, but who knows. 