### PR TITLE
Adapts partially to Py3. Adds a known good npm/nodejs download channel.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ nbmolviz.visualize(benzene)
 
 
 ## Dev install
-Requires npm.
+Requires npm. (Can get through `conda install -c conda-forge nodejs`)
 
     $ git clone https://github.com/autodesk/notebook-molecular-visualization.git
     $ cd notebook-molecular-visualization

--- a/nbmolviz/__init__.py
+++ b/nbmolviz/__init__.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import print_function
 import os as _os
 
 MDTVERSION = '0.8.0'
@@ -49,9 +50,9 @@ def _enable_nbextension():
     try:
         import notebook
         if not notebook.nbextensions.check_nbextension('nbmolviz-js'):
-            print 'Installing Jupyter nbmolviz-js extension...',
+            print('Installing Jupyter nbmolviz-js extension...', end='')
             notebook.nbextensions.install_nbextension_python('nbmolviz')
-            print 'done'
+            print('done')
         notebook.nbextensions.enable_nbextension_python('widgetsnbextension')
         notebook.nbextensions.enable_nbextension_python('nbmolviz')
     except Exception as e:

--- a/nbmolviz/base/molviz2d.py
+++ b/nbmolviz/base/molviz2d.py
@@ -148,5 +148,5 @@ class MolViz2D(MessageWidget):
         Args:
          colormap(Mapping[str,List[Atoms]]): mapping of colors to atoms
         """
-        for color, atoms in colormap.iteritems():
+        for color, atoms in colormap.items():
             self.set_color(atoms=atoms, color=color)

--- a/nbmolviz/base/molviz3d.py
+++ b/nbmolviz/base/molviz3d.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import numpy as np
-from StringIO import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 from traitlets import Bool, Dict, Float, List, Set, Unicode
 
 from ..utils import JSObject, translate_color, in_pixels
@@ -150,7 +153,7 @@ class MolViz3D(MessageWidget):
          colormap(Mapping[str,List[Atoms]]): mapping of colors to atoms
         """
         styles = dict(self.styles)
-        for color, atoms in colormap.iteritems():
+        for color, atoms in colormap.items():
             styles = MolViz3D.get_styles_for_color(color, atoms, styles)
 
         self.styles = styles
@@ -490,9 +493,9 @@ class MolViz3D(MessageWidget):
         print >> fobj, 1, 1
         # finally, write out all the grid values
         # ival = 0
-        for ix in xrange(grid.npoints):
-            for iy in xrange(grid.npoints):
-                for iz in xrange(grid.npoints):
+        for ix in range(grid.npoints):
+            for iy in range(grid.npoints):
+                for iz in range(grid.npoints):
                     print >> fobj, grid.fxyz[ix, iy, iz],
                     # ival += 1
                     # if ival%6 == 0: print >> fobj #newline

--- a/nbmolviz/uielements/configurator.py
+++ b/nbmolviz/uielements/configurator.py
@@ -71,7 +71,7 @@ class Configurator(ipy.Box):
 
     def reset_values(self, *args):
         reset_params = set()
-        for name, value in self.paramlist.iteritems():
+        for name, value in self.paramlist.items():
             if value is not None:
                 self.selectors[name].selector.value = value
             reset_params.add(name)
@@ -82,7 +82,7 @@ class Configurator(ipy.Box):
         self.show_relevant_fields()
 
     def apply_values(self, *args):
-        for paramname, selector in self.selectors.iteritems():
+        for paramname, selector in self.selectors.items():
             self.paramlist[paramname] = selector.selector.value
         self.currentconfig.value = self._pretty_print_config()
         self.show_relevant_fields()
@@ -91,7 +91,7 @@ class Configurator(ipy.Box):
         def cleanse(v):
             if isinstance(v, (float,int)): return v
             else: return str(v)
-        return yaml.dump({k: cleanse(v) for k, v in self.paramlist.iteritems()},
+        return yaml.dump({k: cleanse(v) for k, v in self.paramlist.items()},
                          default_flow_style=False)
 
     def show_relevant_fields(self):

--- a/nbmolviz/uielements/logwidget.py
+++ b/nbmolviz/uielements/logwidget.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import print_function
 import logging
 from collections import OrderedDict
 
@@ -47,7 +48,7 @@ def display_log(obj, title=None, show=False):
     """
 
     if not widgets_enabled:
-        print obj
+        print(obj)
         return
 
     if _current_tabs is None:  # just display the damn thing
@@ -178,7 +179,7 @@ class Logger(ipy.Textarea if widgets_enabled else object):
                 self.active = True
             self.value += string.strip() + '\n'
         else:
-            print string.strip()
+            print(string.strip())
 
     # temporary so that we can use this like a logging module later
     error = warning = info = handled = debug = status = _write
@@ -193,7 +194,7 @@ def _capture_logging_displays(display=False, **kwargs):
     else:
         _current_tabs = None
         enable_logging_widgets(False)
-        print 'Failed to create UI logging system. Logging widgets disabled'
+        print('Failed to create UI logging system. Logging widgets disabled')
 
 
 def _finalize_logging_displays(display=True, **kwargs):

--- a/nbmolviz/utils.py
+++ b/nbmolviz/utils.py
@@ -35,8 +35,12 @@ atomic_numbers = {'Ac': 89, 'Ag': 47, 'Al': 13, 'Am': 95, 'Ar': 18, 'As': 33, 'A
                   'Uuh': 116, 'Uuo': 118, 'Uup': 115, 'Uuq': 114, 'Uus': 117, 'Uut': 113, 'V': 23,
                   'W': 74, 'Xe': 54, 'Y': 39, 'Yb': 70, 'Zn': 30, 'Zr': 40}
 
-elements = {atnum:el for el,atnum in atomic_numbers.iteritems()}
+elements = {atnum:el for el,atnum in atomic_numbers.items()}
 
+try:
+    basestring
+except NameError:
+    basestring = str
 
 def make_layout(layout=None, **kwargs):
     from ipywidgets import Layout
@@ -44,7 +48,7 @@ def make_layout(layout=None, **kwargs):
 
     if layout is None:
         layout = Layout()
-    for key, val in kwargs.iteritems():
+    for key, val in kwargs.items():
         # note that this is the type of the class descriptor, not the instance attribute
         if isinstance(getattr(Layout, key), traitlets.Unicode):
             val = in_pixels(val)

--- a/nbmolviz/viewers/viewer2d.py
+++ b/nbmolviz/viewers/viewer2d.py
@@ -88,7 +88,7 @@ class ChemicalGraphViewer(MolViz2D, ColorMixin):
                 nodes[-1].update({'atom': '',
                                   'size': 0.5,
                                   'color': 'darkgray'})
-            for neighbor, order in atom1.bond_graph.iteritems():
+            for neighbor, order in atom1.bond_graph.items():
                 if neighbor not in self.atom_indices: continue
                 nbr_idx = self.atom_indices[neighbor]
                 if nbr_idx < i1:
@@ -178,7 +178,7 @@ class DistanceGraphViewer(ChemicalGraphViewer):
 
         # Add distance restraints for non-bonded atoms
         for i1, atom1 in enumerate(atoms):
-            for i2 in xrange(i1 + 1, len(atoms)):
+            for i2 in range(i1 + 1, len(atoms)):
                 atom2 = atoms[i2]
                 if atom1 in atom2.bond_graph: continue
 

--- a/nbmolviz/viewers/viewer3d.py
+++ b/nbmolviz/viewers/viewer3d.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import print_function
 import sys
 
 import IPython.display as dsp
@@ -142,7 +143,7 @@ class GeometryViewer(MolViz3D, ColorMixin):
     @utils.doc_inherit
     def set_colors(self, colormap, _store=True):
         if _store:
-            for color, atoms in colormap.iteritems():
+            for color, atoms in colormap.items():
                 for atom in atoms:
                     self._colored_as[atom] = color
         return super(GeometryViewer, self).set_colors(colormap)
@@ -247,8 +248,8 @@ class GeometryViewer(MolViz3D, ColorMixin):
             scale = (lengths.max() / rescale_to)  # units of [vec units] / angstrom
             if hasattr(scale,'defunits'): scale = scale.defunits()
             arrowvecs = vecarray / scale
-            print 'Arrow scale: {q:.3f} {unit} per {native}'.format(q=scale, unit=unit,
-                                                                    native=self.DISTANCE_UNITS)
+            print('Arrow scale: {q:.3f} {unit} per {native}'.format(q=scale, unit=unit,
+                                                                    native=self.DISTANCE_UNITS))
         shapes = []
         for atom, vecarray in zip(self.mol.atoms, arrowvecs):
             if vecarray.norm() < 0.2: continue

--- a/nbmolviz/widget_utils.py
+++ b/nbmolviz/widget_utils.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 
 def can_use_widgets():
@@ -19,7 +20,7 @@ def can_use_widgets():
         return False
 
     if int(ipy.__version__.split('.')[0]) < 6:
-        print 'WARNING: widgets require ipywidgets 6.0 or later'
+        print('WARNING: widgets require ipywidgets 6.0 or later')
         return False
 
     return True

--- a/nbmolviz/widgets/components.py
+++ b/nbmolviz/widgets/components.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import print_function
 import collections
 
 import ipywidgets as ipy
@@ -35,9 +36,10 @@ class AtomInspector(ipy.HTML, Selector):
     Turn atom objects into a value to display
     """
     def atoms_to_value(self, atoms):
-        if len(atoms) == 0:
+        natom = len(list(atoms))
+        if natom == 0:
             return 'No selection'
-        elif len(atoms) == 1:
+        elif natom == 1:
             atom = atoms[0]
             res = atom.residue
             chain = res.chain
@@ -49,7 +51,7 @@ class AtomInspector(ipy.HTML, Selector):
             lines.append("<b>Atom</b> %s (%s), index %d<br>" % (atom.name, atom.symbol, atom.index))
             return '\n'.join(lines)
 
-        elif len(atoms) > 1:
+        elif natom > 1:
             atstrings = ['<b>%s</b>, index %s / res <b>%s</b>, index %s / chain <b>%s</b>' %
                          (a.name, a.index, a.residue.resname, a.residue.index, a.chain.name)
                          for a in atoms]
@@ -170,7 +172,7 @@ class ReadoutFloatSlider(ipy.Box):
             match = utils.GETFLOAT.search(s)
             if match is None:
                 self.readout.value = self.formatstring.format(self.slider.value)
-                print "Couldn't parse string %s" % s
+                print("Couldn't parse string %s" % s)
                 return
             else:
                 f = float(s[match.start():match.end()])

--- a/nbmolviz/widgets/parameterization.py
+++ b/nbmolviz/widgets/parameterization.py
@@ -21,6 +21,7 @@ NOTE:
     This is currently tied to ambertools and tleap! It will need to be made generic if/when
     another method for assigning forcefields is added.
 """
+from __future__ import print_function
 import collections
 
 import ipywidgets as ipy
@@ -35,9 +36,9 @@ def show_parameterization_results(errormessages, molin, molout=None):
         uibase.display_log(report, title='ERRORS/WARNINGS', show=True)
 
     else:
-        print 'Forcefield assignment: %s' % ('Success' if molout is not None else 'Failure')
+        print('Forcefield assignment: %s' % ('Success' if molout is not None else 'Failure'))
         for err in errormessages:
-            print utils.html_to_text(err.desc)
+            print(utils.html_to_text(err.desc))
 
 
 

--- a/nbmolviz/widgets/selector.py
+++ b/nbmolviz/widgets/selector.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # TODO: catch and log event exceptions
+from __future__ import print_function
 import ipywidgets as ipy
 
 from moldesign import utils
@@ -126,7 +127,7 @@ class ValueSelector(Selector):
             if self.value_selects in selection:
                 self.value = selection[self.value_selects]
         except Exception as exc:
-            print 'ERROR: (ignored) %s' % exc
+            print('ERROR: (ignored) %s' % exc)
         self.__hold_fire = False
 
 

--- a/nbmolviz/widgets/trajectory.py
+++ b/nbmolviz/widgets/trajectory.py
@@ -76,7 +76,7 @@ class TrajectoryViewer(selector.SelectionGroup):
         fps = mdt.utils.if_not_none(fps, self.default_fps)
         self.slider.value = 0
         spf = 1.0 / fps
-        for i in xrange(self.viewer.num_frames):
+        for i in range(self.viewer.num_frames):
             t0 = time.time()
             self.slider.value = i
             dt = time.time() - t0


### PR DESCRIPTION
Far from comprehensive, but catches a few Py3 problems I saw in trying to run Tutorial 3. Also specifies conda-forge `nodejs` package as a worthy way to get "npm", rather than the broken `npm` conda package on cpcloud channel.

I notice afterward your py3 branch, so let me know if you'd rather have this PR to that.

Current error for Tutorial 3 is:
```
... last 1 frames repeated, from the frame below ...

~/linux/notebook-molecular-visualization/nbmolviz/widgets/selector.py in __getattr__(self, item)
    105 
    106     def __getattr__(self, item):
--> 107         if self.viewer is not None: return getattr(self.viewer, item)
    108         else: raise AttributeError(item)
    109 

RecursionError: maximum recursion depth exceeded while calling a Python object
```